### PR TITLE
chore: adopt desire state check

### DIFF
--- a/pkg/service/connector.go
+++ b/pkg/service/connector.go
@@ -42,6 +42,19 @@ func (s *service) ProbeSourceConnectors(ctx context.Context, cancel context.Canc
 
 	for _, connector := range connectors {
 		resourceName := util.ConvertRequestToResourceName(connector.Name)
+
+		// if user desires disconnected
+		if connector.Connector.State == connectorPB.Connector_STATE_DISCONNECTED {
+			if err := s.UpdateResourceState(ctx, &controllerPB.Resource{
+				Name: resourceName,
+				State: &controllerPB.Resource_ConnectorState{
+					ConnectorState: connectorPB.Connector_STATE_DISCONNECTED,
+				},
+			}); err != nil {
+				return err
+			}
+		}
+		// if user desires connected
 		workflowId, _ := s.GetResourceWorkflowId(ctx, resourceName)
 		// check if there is an ongoing workflow
 		if workflowId != nil {
@@ -98,6 +111,19 @@ func (s *service) ProbeDestinationConnectors(ctx context.Context, cancel context
 
 	for _, connector := range connectors {
 		resourceName := util.ConvertRequestToResourceName(connector.Name)
+
+		// if user desires disconnected
+		if connector.Connector.State == connectorPB.Connector_STATE_DISCONNECTED {
+			if err := s.UpdateResourceState(ctx, &controllerPB.Resource{
+				Name: resourceName,
+				State: &controllerPB.Resource_ConnectorState{
+					ConnectorState: connectorPB.Connector_STATE_DISCONNECTED,
+				},
+			}); err != nil {
+				return err
+			}
+		}
+		// if user desires connected
 		workflowId, _ := s.GetResourceWorkflowId(ctx, resourceName)
 		// check if there is an ongoing workflow
 		if workflowId != nil {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -51,9 +51,21 @@ func (s *service) ProbePipelines(ctx context.Context, cancel context.CancelFunc)
 		pipelineResource := controllerPB.Resource{
 			Name: resourceName,
 			State: &controllerPB.Resource_PipelineState{
-				PipelineState: pipelinePB.Pipeline_STATE_ERROR,
+				PipelineState: pipelinePB.Pipeline_STATE_INACTIVE,
 			},
 		}
+
+		// user desires inactive
+		if pipeline.State == pipelinePB.Pipeline_STATE_INACTIVE {
+			if err := s.UpdateResourceState(ctx, &pipelineResource); err != nil {
+				return err
+			} else {
+				return nil
+			}
+		}
+
+		// user desires active, now check each component's state
+		pipelineResource.State = &controllerPB.Resource_PipelineState{PipelineState: pipelinePB.Pipeline_STATE_ERROR}
 
 		var resources []*controllerPB.Resource
 


### PR DESCRIPTION
Because

- account for user desire state while probing

This commit

- add disconnected/inactive desire state check
