### PR TITLE
ci(action): update workflow components align with vdp main branch

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [pipeline, connector, model, mgmt]
+        component: [pipeline-backend, connector-backend, model-backend, mgmt-backend, controller]
     uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}


### PR DESCRIPTION
Because

- vdp main workflow files updated component naming

This commit

- update component names in workflow call
