### PR TITLE
chore(connector): remove workflow check for connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35
 	github.com/knadh/koanf v1.5.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/rs/cors v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b h1:b4hJdJlcb+8ql+oRF/9Dm4UBgQCQMuk4dcBOw3R2N4c=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35 h1:KMwDmSv3HazGi4+4uWoXfDZyMG5eFti/dHGhJrmzjWg=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=

--- a/pkg/service/mock_model_client_test.go
+++ b/pkg/service/mock_model_client_test.go
@@ -36,26 +36,6 @@ func (m *MockModelPublicServiceClient) EXPECT() *MockModelPublicServiceClientMoc
 	return m.recorder
 }
 
-// CancelModelOperation mocks base method.
-func (m *MockModelPublicServiceClient) CancelModelOperation(arg0 context.Context, arg1 *modelv1alpha.CancelModelOperationRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CancelModelOperationResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "CancelModelOperation", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.CancelModelOperationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CancelModelOperation indicates an expected call of CancelModelOperation.
-func (mr *MockModelPublicServiceClientMockRecorder) CancelModelOperation(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelModelOperation", reflect.TypeOf((*MockModelPublicServiceClient)(nil).CancelModelOperation), varargs...)
-}
-
 // CreateModel mocks base method.
 func (m *MockModelPublicServiceClient) CreateModel(arg0 context.Context, arg1 *modelv1alpha.CreateModelRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CreateModelResponse, error) {
 	m.ctrl.T.Helper()
@@ -234,26 +214,6 @@ func (mr *MockModelPublicServiceClientMockRecorder) ListModelDefinitions(arg0, a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelDefinitions), varargs...)
-}
-
-// ListModelOperations mocks base method.
-func (m *MockModelPublicServiceClient) ListModelOperations(arg0 context.Context, arg1 *modelv1alpha.ListModelOperationsRequest, arg2 ...grpc.CallOption) (*modelv1alpha.ListModelOperationsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ListModelOperations", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.ListModelOperationsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListModelOperations indicates an expected call of ListModelOperations.
-func (mr *MockModelPublicServiceClientMockRecorder) ListModelOperations(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelOperations", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelOperations), varargs...)
 }
 
 // ListModels mocks base method.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -367,14 +367,8 @@ func (s *service) getOperationInfo(workflowId string, resourceType string) (*lon
 			return nil, err
 		}
 		operation = op.Operation
-	case util.RESOURCE_TYPE_SOURCE_CONNECTOR, util.RESOURCE_TYPE_DESTINATION_CONNECTOR:
-		op, err := s.connectorPublicClient.GetConnectorOperation(ctx, &connectorPB.GetConnectorOperationRequest{
-			Name: fmt.Sprintf("operations/%s", workflowId),
-		})
-		if err != nil {
-			return nil, err
-		}
-		operation = op.Operation
+	default:
+		return nil, fmt.Errorf("resource type %s workflow not implemented", resourceType)
 	}
 
 	return operation, nil


### PR DESCRIPTION
Because

- check connector is now sync

This commit

- adopt connector checking to be sync
- drop workflow checking for connector
