### PR TITLE
chore(connector,model): update client to private

### DIFF
--- a/pkg/service/connector.go
+++ b/pkg/service/connector.go
@@ -19,7 +19,7 @@ func (s *service) ProbeSourceConnectors(ctx context.Context, cancel context.Canc
 
 	var wg sync.WaitGroup
 
-	resp, err := s.connectorPublicClient.ListSourceConnectors(ctx, &connectorPB.ListSourceConnectorsRequest{})
+	resp, err := s.connectorPrivateClient.ListSourceConnectorsAdmin(ctx, &connectorPB.ListSourceConnectorsAdminRequest{})
 
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func (s *service) ProbeSourceConnectors(ctx context.Context, cancel context.Canc
 	wg.Add(int(totalSize))
 
 	for totalSize > util.DefaultPageSize {
-		resp, err := s.connectorPublicClient.ListSourceConnectors(ctx, &connectorPB.ListSourceConnectorsRequest{
+		resp, err := s.connectorPrivateClient.ListSourceConnectorsAdmin(ctx, &connectorPB.ListSourceConnectorsAdminRequest{
 			PageToken: nextPageToken,
 		})
 
@@ -111,7 +111,7 @@ func (s *service) ProbeDestinationConnectors(ctx context.Context, cancel context
 
 	var wg sync.WaitGroup
 
-	resp, err := s.connectorPublicClient.ListDestinationConnectors(ctx, &connectorPB.ListDestinationConnectorsRequest{})
+	resp, err := s.connectorPrivateClient.ListDestinationConnectorsAdmin(ctx, &connectorPB.ListDestinationConnectorsAdminRequest{})
 
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (s *service) ProbeDestinationConnectors(ctx context.Context, cancel context
 	totalSize := resp.TotalSize
 
 	for totalSize > util.DefaultPageSize {
-		resp, err := s.connectorPublicClient.ListDestinationConnectors(ctx, &connectorPB.ListDestinationConnectorsRequest{
+		resp, err := s.connectorPrivateClient.ListDestinationConnectorsAdmin(ctx, &connectorPB.ListDestinationConnectorsAdminRequest{
 			PageToken: nextPageToken,
 		})
 

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -19,7 +19,7 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 
 	var wg sync.WaitGroup
 
-	resp, err := s.modelPublicClient.ListModels(ctx, &modelPB.ListModelsRequest{})
+	resp, err := s.modelPrivateClient.ListModelsAdmin(ctx, &modelPB.ListModelsAdminRequest{})
 
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 	totalSize := resp.TotalSize
 
 	for totalSize > util.DefaultPageSize {
-		resp, err := s.modelPublicClient.ListModels(ctx, &modelPB.ListModelsRequest{
+		resp, err := s.modelPrivateClient.ListModelsAdmin(ctx, &modelPB.ListModelsAdminRequest{
 			PageToken: nextPageToken,
 		})
 


### PR DESCRIPTION
Because

- list with private service to get all users' resources

This commit

- update connector and model service to private
