### PR TITLE
chore: refactor integration-test mode

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (model)
         uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (mgmt)
         uses: actions/checkout@v3
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (connector)
         uses: actions/checkout@v3
@@ -170,4 +170,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ unit-test:       				## Run unit test
 
 .PHONY: integration-test
 integration-test:				## Run integration test
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/grpc.js --no-usage-report --quiet
+	TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/grpc.js --no-usage-report --quiet
 
 .PHONY: help
 help:       	 				## Show this help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -2,30 +2,23 @@ let proto
 let tHost, mgHost, pHost, cHost, mHost, ctHost
 let tPublicPort, mgPublicPort, mgPrivatePort, pPublicPort, pPrivatePort, cPublicPort, cPrivatePort, mPublicPort, mPrivatePort, ctPrivatePort
 
-if (__ENV.MODE == "api-gateway") {
-  // api-gateway mode for accessing api-gateway directly
+if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
+  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+}
+
+export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+
+if (__ENV.API_GATEWAY_PROTOCOL) {
+  if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
+    fail("only allow `http` or `https` for API_GATEWAY_PROTOCOL")
+  }
+  proto = __ENV.API_GATEWAY_PROTOCOL
+} else {
   proto = "http"
-  pHost = cHost = mHost = tHost = mgHost = ctHost = "api-gateway"
-  pPrivatePort = 3081
-  cPrivatePort = 3082
-  mPrivatePort = 3083
-  mgPrivatePort = 3084
-  ctPrivatePort = 3085
-  tPublicPort = mgPublicPort = pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "localhost") {
-  // localhost mode for accessing api-gateway from localhost
-  proto = "http"
-  pHost = cHost = mHost = tHost = mgHost = ctHost = "localhost"
-  pPrivatePort = 3081
-  cPrivatePort = 3082
-  mPrivatePort = 3083
-  mgPrivatePort = 3084
-  ctPrivatePort = 3085
-  tPublicPort = mgPublicPort = pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "internal") {
-  // localhost mode for accessing api-gateway from internal
-  proto = "http"
-  pHost = cHost = mHost = tHost = mgHost = ctHost = "host.docker.internal"
+}
+if (apiGatewayMode) {
+  // api-gateway mode
+  pHost = cHost = mHost = tHost = mgHost = ctHost = __ENV.API_GATEWAY_HOST
   pPrivatePort = 3081
   cPrivatePort = 3082
   mPrivatePort = 3083
@@ -34,7 +27,6 @@ if (__ENV.MODE == "api-gateway") {
   tPublicPort = mgPublicPort = pPublicPort = cPublicPort = mPublicPort = 8080
 } else {
   // direct microservice mode
-  proto = "http"
   tHost = "triton-server"
   mgHost = "mgmt-backend"
   pHost = "pipeline-backend"

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -22,7 +22,7 @@ export default function (data) {
   /*
    * Controller API - API CALLS
    */
-  if (__ENV.MODE != "api-gateway") {
+  if (!constant.apiGatewayMode) {
     // Health check
     group("Controller API: Health check", () => {
       client.connect(constant.controllerGRPCPrivateHost, {
@@ -50,7 +50,7 @@ export default function (data) {
 }
 
 export function teardown(data) {
-  if (__ENV.MODE != "api-gateway") {
+  if (!constant.apiGatewayMode) {
     client.connect(constant.controllerGRPCPrivateHost, {
       plaintext: true
     });


### PR DESCRIPTION
Because

* add definable api-gateway host for integration-test 

This commit

* add API_GATEWAY_HOST, API_GATEWAY_PORT and API_GATEWAY_PROTOCOL var. to simplify the integration test setting