### PR TITLE
chore: remove usage of resource name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4
 	github.com/knadh/koanf v1.5.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/rs/cors v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b h1:b4hJdJlcb+8ql+oRF/9Dm4UBgQCQMuk4dcBOw3R2N4c=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230408173208-d25777f1f97b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4 h1:FN31oB55KUcvrj6aSYOWKQGnTT/fL4vg4PqUvkX7jV4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,11 +2,9 @@ package util
 
 import (
 	"fmt"
-	"strings"
 )
 
-func ConvertRequestToResourceName(requestName string, uid string) string {
-	resourceType := strings.SplitN(requestName, "/", 2)[0]
+func ConvertUIDToResourcePermalink(uid string, resourceType string) string {
 	resourceName := fmt.Sprintf("resources/%s/types/%s", uid, resourceType)
 
 	return resourceName
@@ -18,8 +16,8 @@ func ConvertServiceToResourceName(serviceName string) string {
 	return resourceName
 }
 
-func ConvertWorkflfowToWorkflowResourceName(resourceName string) string {
-	resourceWorkflowId := fmt.Sprintf("%s/workflow", resourceName)
+func ConvertResourcePermalinkToWorkflowName(resourcePermalink string) string {
+	resourceWorkflowId := fmt.Sprintf("%s/workflow", resourcePermalink)
 
 	return resourceWorkflowId
 }

--- a/pkg/service/mock_model_client_test.go
+++ b/pkg/service/mock_model_client_test.go
@@ -36,26 +36,6 @@ func (m *MockModelPublicServiceClient) EXPECT() *MockModelPublicServiceClientMoc
 	return m.recorder
 }
 
-// CancelModelOperation mocks base method.
-func (m *MockModelPublicServiceClient) CancelModelOperation(arg0 context.Context, arg1 *modelv1alpha.CancelModelOperationRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CancelModelOperationResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "CancelModelOperation", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.CancelModelOperationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CancelModelOperation indicates an expected call of CancelModelOperation.
-func (mr *MockModelPublicServiceClientMockRecorder) CancelModelOperation(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelModelOperation", reflect.TypeOf((*MockModelPublicServiceClient)(nil).CancelModelOperation), varargs...)
-}
-
 // CreateModel mocks base method.
 func (m *MockModelPublicServiceClient) CreateModel(arg0 context.Context, arg1 *modelv1alpha.CreateModelRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CreateModelResponse, error) {
 	m.ctrl.T.Helper()
@@ -234,26 +214,6 @@ func (mr *MockModelPublicServiceClientMockRecorder) ListModelDefinitions(arg0, a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelDefinitions), varargs...)
-}
-
-// ListModelOperations mocks base method.
-func (m *MockModelPublicServiceClient) ListModelOperations(arg0 context.Context, arg1 *modelv1alpha.ListModelOperationsRequest, arg2 ...grpc.CallOption) (*modelv1alpha.ListModelOperationsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ListModelOperations", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.ListModelOperationsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListModelOperations indicates an expected call of ListModelOperations.
-func (mr *MockModelPublicServiceClientMockRecorder) ListModelOperations(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelOperations", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelOperations), varargs...)
 }
 
 // ListModels mocks base method.

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -204,7 +204,7 @@ func TestUpdateResourceState(t *testing.T) {
 		}
 
 		resource := controllerPB.Resource{
-			Name: serviceResourceName,
+			ResourcePermalink: serviceResourceName,
 			State: &controllerPB.Resource_BackendState{
 				BackendState: healthcheckPB.HealthCheckResponse_SERVING_STATUS_UNSPECIFIED,
 			},
@@ -243,7 +243,7 @@ func TestUpdateResourceState(t *testing.T) {
 		}
 
 		resource := controllerPB.Resource{
-			Name: modelResourceName,
+			ResourcePermalink: modelResourceName,
 			State: &controllerPB.Resource_ModelState{
 				ModelState: modelPB.Model_STATE_UNSPECIFIED,
 			},
@@ -282,7 +282,7 @@ func TestUpdateResourceState(t *testing.T) {
 		}
 
 		resource := controllerPB.Resource{
-			Name: connectorResourceName,
+			ResourcePermalink: connectorResourceName,
 			State: &controllerPB.Resource_ConnectorState{
 				ConnectorState: connectorPB.Connector_STATE_UNSPECIFIED,
 			},
@@ -321,7 +321,7 @@ func TestUpdateResourceState(t *testing.T) {
 		}
 
 		resource := controllerPB.Resource{
-			Name: pipelineResourceName,
+			ResourcePermalink: pipelineResourceName,
 			State: &controllerPB.Resource_PipelineState{
 				PipelineState: pipelinePB.Pipeline_STATE_UNSPECIFIED,
 			},


### PR DESCRIPTION
Because

- allow same resource name under different user namespace

This commit

- remove resource name usage and use resource uuid instead
