### PR TITLE
chore(connector): disable connector probe

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -226,18 +226,19 @@ func main() {
 			}()
 
 			// Connectors
-			go func() {
-				defer mainWG.Done()
-				if err := service.ProbeSourceConnectors(context.WithTimeout(ctx, config.Config.Server.Timeout*time.Second)); err != nil {
-					logger.Error(err.Error())
-				}
-			}()
-			go func() {
-				defer mainWG.Done()
-				if err := service.ProbeDestinationConnectors(context.WithTimeout(ctx, config.Config.Server.Timeout*time.Second)); err != nil {
-					logger.Error(err.Error())
-				}
-			}()
+			// TODO: Temporary disable connector probing due to airbyte container spawn usage burst, will be revisited
+			// go func() {
+			// 	defer mainWG.Done()
+			// 	if err := service.ProbeSourceConnectors(context.WithTimeout(ctx, config.Config.Server.Timeout*time.Second)); err != nil {
+			// 		logger.Error(err.Error())
+			// 	}
+			// }()
+			// go func() {
+			// 	defer mainWG.Done()
+			// 	if err := service.ProbeDestinationConnectors(context.WithTimeout(ctx, config.Config.Server.Timeout*time.Second)); err != nil {
+			// 		logger.Error(err.Error())
+			// 	}
+			// }()
 
 			// Pipelines
 			go func() {


### PR DESCRIPTION
Because

- check connector workflow will spawn too many airbyte containers at the same time and cause resource problem

This commit

- disable connector probing temporary and to be revisited in the future with better solution
