### PR TITLE
chore: add a workaround method for goroutine order problem

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -227,6 +227,9 @@ func main() {
 	span.End()
 	logger.Info("gRPC server is running.")
 
+	// Workaround, wait the http server ready
+	time.Sleep(10 * time.Second)
+
 	go func() {
 		// repopulate connector resource
 		isRepopulate := false


### PR DESCRIPTION
Because

- the controller probe mechanism failed sometimes

This commit

- fix the problem caused by order of goroutines 
